### PR TITLE
Feat: Add fixed NPUB url param to rating

### DIFF
--- a/src/routes/keys/+page.svelte
+++ b/src/routes/keys/+page.svelte
@@ -1,25 +1,42 @@
 <script lang="ts">
-	import { goto } from "$app/navigation";
-	import { nostrAuth } from "$lib/nostr";
-	import { Button } from "flowbite-svelte";
-	import { nip19 } from "nostr-tools";
-	import { onMount } from "svelte";
+	import { goto } from '$app/navigation';
+	import { nostrAuth } from '$lib/nostr';
+	import { Button } from 'flowbite-svelte';
+	import { nip19 } from 'nostr-tools';
+	import { onMount } from 'svelte';
+
+	import { page } from '$app/state';
 
 	onMount(() => {
 		if (window.nostr) nostrAuth.tryLogin();
-	})
+	});
 </script>
 
-<div class="flex flex-col items-center justify-center h-screen w-full gap-4">
+<div class="flex h-screen w-full flex-col items-center justify-center gap-4">
 	{#if !$nostrAuth?.privkey && $nostrAuth?.pubkey}
-		<h1 class="text-3xl text-center">Logged in with nostr browser extension</h1>
+		<h1 class="text-center text-3xl">Logged in with nostr browser extension</h1>
 	{/if}
 
 	{#if $nostrAuth?.pubkey}
-		<p class="text-center break-all px-2">
+		<p class="break-all px-2 text-center">
 			Your public ID: <br />
 			{nip19.npubEncode($nostrAuth?.pubkey)}
 		</p>
+
+		<Button
+			on:click={async () => {
+				try {
+					await navigator.clipboard.writeText(
+						`${page.url.origin}/rate?npub=${nip19.npubEncode($nostrAuth?.pubkey)}`
+					);
+					alert('URL Copied!');
+				} catch (error) {
+					console.error('Failed to copy share URL:', error);
+				}
+			}}
+		>
+			Copy rate url
+		</Button>
 
 		<Button
 			on:click={() => {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,11 +3,20 @@
 	import { nostrAuth } from '$lib/nostr';
 	import { P, Button } from 'flowbite-svelte';
 
+	import { page } from '$app/state';
+	const npub = page.url.searchParams.get('npub');
+	const urlParams = npub ? `?npub=${npub}` : '';
+
 	async function useAlby() {
 		try {
 			await window.nostr!.getPublicKey();
 
 			await nostrAuth.tryLogin();
+
+			if (npub) {
+				return goto(`/rate${urlParams}`);
+			}
+
 			goto('/');
 		} catch (error) {
 			alert("You haven't allowed Alby to connect with the app");
@@ -15,16 +24,16 @@
 	}
 </script>
 
-<div class="flex flex-col justify-center h-full gap-4 p-4">
+<div class="flex h-full flex-col justify-center gap-4 p-4">
 	<div class="flex justify-center">
 		<P size="4xl" weight="normal">PLS Identity Login</P>
 	</div>
 
-	<div class="flex flex-col justify-center items-center h-full gap-4">
-		<a href="/login/new">
+	<div class="flex h-full flex-col items-center justify-center gap-4">
+		<a href={`/login/new${urlParams}`}>
 			<Button class="w-48 md:w-64">New</Button>
 		</a>
-		<a href="/login/import">
+		<a href={`/login/import${urlParams}`}>
 			<Button class="w-48 md:w-64">Import / Recover</Button>
 		</a>
 		{#if window.nostr}

--- a/src/routes/login/import/+page.svelte
+++ b/src/routes/login/import/+page.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
-	import { nostrAuth } from "$lib/nostr";
-	import { Button, Input, Label, P } from "flowbite-svelte";
-	import { Buffer } from "buffer";
-	import { nip19 } from "nostr-tools";
+	import { nostrAuth } from '$lib/nostr';
+	import { Button, Input, Label, P } from 'flowbite-svelte';
+	import { Buffer } from 'buffer';
+	import { nip19 } from 'nostr-tools';
+
+	import { page } from '$app/state';
+	const npubParam = page.url.searchParams.get('npub');
+	const urlParams = npubParam ? `?npub=${npubParam}` : '';
 
 	let nsecInput = '';
 
 	let secretKey: Uint8Array | null = null;
 	let secretKeyStr: string | null = null;
 
-	$:{
+	$: {
 		try {
 			let nsec = nip19.decode(nsecInput);
 
@@ -27,22 +31,21 @@
 	}
 </script>
 
-<div class="w-full flex flex-col justify-center items-center h-full gap-4 p-4">
+<div class="flex h-full w-full flex-col items-center justify-center gap-4 p-4">
 	<div class="flex justify-center">
 		<P align="center" size="4xl" weight="normal">Import PLS Identity</P>
 	</div>
-	<div class="flex justify-center w-full flex-col items-center h-full gap-4">
+	<div class="flex h-full w-full flex-col items-center justify-center gap-4">
 		<div>
 			<Label class="mb-2">Secret key</Label>
 			<Input type="text" bind:value={nsecInput}></Input>
 		</div>
 	</div>
-	<a href="/">
+	<a href={npubParam ? `/rate${urlParams}` : '/'}>
 		<Button
 			disabled={secretKeyStr === null}
 			on:click={() => {
-				if (secretKeyStr)
-					nostrAuth.loginWithPrivkey(secretKeyStr);
+				if (secretKeyStr) nostrAuth.loginWithPrivkey(secretKeyStr);
 			}}
 		>
 			Continue

--- a/src/routes/login/new/+page.svelte
+++ b/src/routes/login/new/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-	import { Button, Checkbox, Input, Label, P, Toast } from "flowbite-svelte";
-	import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
-	import { Buffer } from "buffer";
-	import { slide } from "svelte/transition";
-	import { nostrAuth } from "$lib/nostr";
+	import { Button, Checkbox, Input, Label, P, Toast } from 'flowbite-svelte';
+	import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
+	import { Buffer } from 'buffer';
+	import { slide } from 'svelte/transition';
+	import { nostrAuth } from '$lib/nostr';
+
+	import { page } from '$app/state';
+	const npubParam = page.url.searchParams.get('npub');
+	const urlParams = npubParam ? `?npub=${npubParam}` : '';
 
 	let privateKey = generateSecretKey();
 	let privateKeyStr = Buffer.from(privateKey).toString('hex');
@@ -18,13 +22,12 @@
 	let copiedPrivkey = false;
 </script>
 
-<div class="w-full flex flex-col justify-center items-center h-full gap-4 p-4">
+<div class="flex h-full w-full flex-col items-center justify-center gap-4 p-4">
 	<div class="flex justify-center">
 		<P align="center" size="4xl" weight="normal">Generated PLS Identity</P>
 	</div>
 
-	<div class="flex justify-center w-full flex-col items-center h-full gap-4">
-
+	<div class="flex h-full w-full flex-col items-center justify-center gap-4">
 		<div>
 			<Label class="mb-2">Public ID</Label>
 			<Input
@@ -41,7 +44,12 @@
 				}}
 			/>
 		</div>
-		<Toast class="dark:bg-slate-700 rounded-lg m-3 w-max" dismissable={false} bind:toastStatus={copiedPubkey} transition={slide}>
+		<Toast
+			class="m-3 w-max rounded-lg dark:bg-slate-700"
+			dismissable={false}
+			bind:toastStatus={copiedPubkey}
+			transition={slide}
+		>
 			Copied public ID to clipboard.
 		</Toast>
 
@@ -61,7 +69,12 @@
 				}}
 			/>
 		</div>
-		<Toast class="dark:bg-slate-700 rounded-lg m-3 w-max" dismissable={false} bind:toastStatus={copiedPrivkey} transition={slide}>
+		<Toast
+			class="m-3 w-max rounded-lg dark:bg-slate-700"
+			dismissable={false}
+			bind:toastStatus={copiedPrivkey}
+			transition={slide}
+		>
 			Copied secret key to clipboard.
 		</Toast>
 	</div>
@@ -70,7 +83,7 @@
 		I've stored my secret key in a safe and private place
 	</Checkbox>
 
-	<a href="/">
+	<a href={npubParam ? `/rate${urlParams}` : '/'}>
 		<Button disabled={!hasStoredKey} on:click={() => nostrAuth.loginWithPrivkey(privateKeyStr)}>
 			Continue
 		</Button>

--- a/src/routes/rate/+page.svelte
+++ b/src/routes/rate/+page.svelte
@@ -1,47 +1,47 @@
 <script lang="ts">
-	import { ReviewEvent } from "$lib";
+	import { ReviewEvent } from '$lib';
 
-	import { getPublicKey } from "nostr-tools/pure";
-	import { broadcastToNostr } from "$lib/nostr";
-	import { decode, npubEncode } from "nostr-tools/nip19";
-	import { goto } from "$app/navigation";
-	import { nostrAuth } from "$lib/nostr";
-	import { Button, Input, Label, Textarea, Radio } from "flowbite-svelte";
+	import { getPublicKey } from 'nostr-tools/pure';
+	import { broadcastToNostr } from '$lib/nostr';
+	import { decode, npubEncode } from 'nostr-tools/nip19';
+	import { goto } from '$app/navigation';
+	import { nostrAuth } from '$lib/nostr';
+	import { Button, Input, Label, Textarea, Radio } from 'flowbite-svelte';
+
+	import { page } from '$app/state';
+	const npub = page.url.searchParams.get('npub');
 
 	function parsePubKey(str: string) {
 		try {
-			const nip19 = decode(str)
+			const nip19 = decode(str);
 
-			if (nip19.type == "npub") return hexStringToBuffer(nip19.data)
+			if (nip19.type == 'npub') return hexStringToBuffer(nip19.data);
 		} catch {
 			try {
-				const buf = hexStringToBuffer(str)
+				const buf = hexStringToBuffer(str);
 
 				if (buf.length !== 32) return;
 
-				return buf
+				return buf;
 			} catch {}
 		}
 	}
 
 	function hexStringToBuffer(str: string) {
-		return Uint8Array.from(toHex(str))
+		return Uint8Array.from(toHex(str));
 	}
 
 	function toHex(hexString: string) {
-		let hex = []
+		let hex = [];
 
-		let i = 0
+		let i = 0;
 		while (i < hexString.length) {
-			hex[i/2] = parseInt(
-				hexString[i] + hexString[i+1],
-				16
-			)
+			hex[i / 2] = parseInt(hexString[i] + hexString[i + 1], 16);
 
-			i += 2
+			i += 2;
 		}
 
-		return hex
+		return hex;
 	}
 
 	function numberToHex(i: number) {
@@ -53,50 +53,52 @@
 	}
 
 	interface Review {
-		from: string,
-		to: string,
-		score: boolean,
-		businessAlreadyDone: boolean,
-		description: string
+		from: string;
+		to: string;
+		score: boolean;
+		businessAlreadyDone: boolean;
+		description: string;
 	}
 
-	let otherPersonPubKey = ""
-	let ratingDescription = ""
-	let score: number | undefined
-	let businessAlreadyDone: number | undefined
+	let otherPersonPubKey = npub ?? '';
+	let ratingDescription = '';
+	let score: number | undefined;
+	let businessAlreadyDone: number | undefined;
 
 	async function handleSubmit() {
 		if (ratingDescription.length >= 1000)
-			return alert("2000 characters is the max for a rating description")
+			return alert('2000 characters is the max for a rating description');
 
 		if (score == undefined || businessAlreadyDone == undefined)
-			return alert("You forgot to fill some checkbox")
+			return alert('You forgot to fill some checkbox');
 
 		const privkey = nostrAuth.getPrivkey();
 
 		if (privkey) {
-			nostrAuth.loginWithPrivkey(privkey)
+			nostrAuth.loginWithPrivkey(privkey);
 		}
-		
-		if (!nostrAuth) return alert("Invalid secret key")
-		
-		const myPubkey = !!nostrAuth ? nostrAuth.getPubkey()! : getPublicKey(Buffer.from(privkey!, 'hex'))
 
-		const otherPubKey = parsePubKey(otherPersonPubKey)
-		if (!otherPubKey) return alert("Invalid public key")
+		if (!nostrAuth) return alert('Invalid secret key');
 
-		const ratedPubKey = bufToHexString(otherPubKey)
+		const myPubkey = !!nostrAuth
+			? nostrAuth.getPubkey()!
+			: getPublicKey(Buffer.from(privkey!, 'hex'));
+
+		const otherPubKey = parsePubKey(otherPersonPubKey);
+		if (!otherPubKey) return alert('Invalid public key');
+
+		const ratedPubKey = bufToHexString(otherPubKey);
 		let rating: Review = {
 			from: myPubkey,
 			to: ratedPubKey,
 			score: Boolean(score),
 			businessAlreadyDone: Boolean(businessAlreadyDone),
-			description: ratingDescription,
+			description: ratingDescription
 		};
 
-		const labelTag = ['l', `pls-wot-rating`]
-		const dTag = ['d', `pls-wot-rating-${ratedPubKey}`]
-		const event = await nostrAuth.makeEvent(ReviewEvent, JSON.stringify(rating), [labelTag, dTag])
+		const labelTag = ['l', `pls-wot-rating`];
+		const dTag = ['d', `pls-wot-rating-${ratedPubKey}`];
+		const event = await nostrAuth.makeEvent(ReviewEvent, JSON.stringify(rating), [labelTag, dTag]);
 
 		// const event = finalizeEvent({
 		// 		content: JSON.stringify(rating),
@@ -105,48 +107,50 @@
 		// 		tags: []
 		// }, mySecKey)
 
-		console.log(event)
+		console.log(event);
 
 		// TODO: Sign review, let user download it, and disabled 'send to nostr' button
 		// 'send to nostr' should be in a parameterized replaceable event (but just do ephemeral for now)
 
 		// relayPool.publish(relayList, event)
-		broadcastToNostr(event)
+		broadcastToNostr(event);
 
-		if (confirm("Event published. Would you like to see the ratings table?")) {
-			goto("/table")
+		if (confirm('Event published. Would you like to see the ratings table?')) {
+			goto('/table');
 		}
 
-		otherPersonPubKey = ""
-		ratingDescription = ""
-		score = undefined
-		businessAlreadyDone = undefined
+		otherPersonPubKey = '';
+		ratingDescription = '';
+		score = undefined;
+		businessAlreadyDone = undefined;
 	}
 
-	$: if (!$nostrAuth?.pubkey) goto("/");
+	$: if (!$nostrAuth?.pubkey) {
+		let urlParams = npub ? `?npub=${npub}` : '';
+		goto(`/login${urlParams}`);
+	}
 </script>
 
-
 <form
-	on:submit={(e)=>{
-		e.preventDefault()
-		handleSubmit()
+	on:submit={(e) => {
+		e.preventDefault();
+		handleSubmit();
 	}}
-	class="flex flex-col h-full justify-center items-center gap-4 pt-4"
+	class="flex h-full flex-col items-center justify-center gap-4 pt-4"
 >
 	{#if $nostrAuth?.pubkey}
-		<Label class="flex flex-col w-1/2">
+		<Label class="flex w-1/2 flex-col">
 			Your npub
 			<code class="font-bold">{npubEncode($nostrAuth.pubkey)}</code>
 		</Label>
 	{/if}
 
-	<Label class="flex flex-col w-1/2">
+	<Label class="flex w-1/2 flex-col">
 		Other person pubkey
 		<Input class="border-2" bind:value={otherPersonPubKey} type="text" />
 	</Label>
 
-	<div class="flex flex-col w-1/2">
+	<div class="flex w-1/2 flex-col">
 		<p>What rating do you give to this person?</p>
 		<div class="flex gap-4">
 			<Label class="flex items-center gap-1">
@@ -160,7 +164,7 @@
 		</div>
 	</div>
 
-	<div class="flex flex-col w-1/2">
+	<div class="flex w-1/2 flex-col">
 		<p>Have you ever done business with this person?</p>
 		<div class="flex gap-4">
 			<Label class="flex items-center gap-1">
@@ -174,11 +178,10 @@
 		</div>
 	</div>
 
-	<Label class="flex flex-col w-1/2">
+	<Label class="flex w-1/2 flex-col">
 		Rating description
 		<Textarea rows={6} class="border-2" bind:value={ratingDescription} />
 	</Label>
 
-	<Button type="submit" class="w-48 m:w-64">Create rating</Button>
+	<Button type="submit" class="m:w-64 w-48">Create rating</Button>
 </form>
-

--- a/src/routes/rate/+page.svelte
+++ b/src/routes/rate/+page.svelte
@@ -147,7 +147,12 @@
 
 	<Label class="flex w-1/2 flex-col">
 		Other person pubkey
-		<Input class="border-2" bind:value={otherPersonPubKey} type="text" />
+		<Input
+			class="border-2"
+			bind:value={otherPersonPubKey}
+			type="text"
+			readonly={otherPersonPubKey != ''}
+		/>
 	</Label>
 
 	<div class="flex w-1/2 flex-col">


### PR DESCRIPTION
A improvement idea from [IgorMoita](https://discordapp.com/users/187314010922680332)

https://discord.com/channels/976492567367667763/1364679841290649672
```
Currently when a user gets onto the MVP (after Login) they are able to fill in the rating page and send a rate for some NPUB.

My idea is a way to fix the rated NPUB (currently called "Other person pubkey"), so when the user access this URL he will do Import/New (login in) and get straight way to the "rating page" with the fixed NPUB on "Other person pubkey"

Why is it important?
My self trying to get rates from my customers, I send them the URL with my own NPUB, when the customer login in the rating page is filled in automatically with my own NPUB, making sure the customer will rate my NPUB.
```

<hr>

Changes:
- Added a param `npub` for some pages (rate and login)
- When `npub` param specified fill rate form automatically
- If user is not logged, the param persists on login page and redirect into rate page on logged
- Added a button inside `/keys` page (profile) to copy rating url with `npub` param specified